### PR TITLE
Add option `enable_transparency_image`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ $("#canvas").drawr("start");
 
 **Options**
 
-1.  enable_tranparency
-2.  canvas_width
-3.  canvas_height
-4.  undo_max_levels(5)
-5.  color_mode("presets","picker")
-6.  clear_on_init
+1.  enable_tranparency(true)
+2.  enable_tranparency_image(true)
+3.  canvas_width
+4.  canvas_height
+5.  undo_max_levels(5)
+6.  color_mode("presets","picker")
+7.  clear_on_init(true)
 
 [demos and docs at this link](https://rawrfl.es/jquery-drawr/ "demos and docs at this link")
 

--- a/src/jquery.drawr.js
+++ b/src/jquery.drawr.js
@@ -398,7 +398,7 @@
         	this.origParentStyles = plugin.get_styles($(this).parent()[0]);
         	$(this).css({ "display" : "block", "user-select": "none", "webkit-touch-callout": "none" });
         	$(this).parent().css({	"overflow": "hidden", "user-select": "none", "webkit-touch-callout": "none" });
-        	if(this.settings.enable_tranparency==true) $(this).css({"background-image" : "url(" + tspImg + ")"});
+        	if(this.settings.enable_tranparency_image==true) $(this).css({"background-image" : "url(" + tspImg + ")"});
 
         	if(this.width!==width || this.height!==height){//if statement because it resets otherwise.
 				this.width=width;
@@ -772,6 +772,7 @@
 	        	//determine settings
 		    	var defaultSettings = {
 		    		"enable_tranparency" : true,
+					"enable_tranparency_image" : true,
 		    		"canvas_width" : $(currentCanvas).parent().innerWidth(),
 		    		"canvas_height" : $(currentCanvas).parent().innerHeight(),
 		    		"undo_max_levels" : 5,


### PR DESCRIPTION
The following PR adds another option to explicitly turn the default image on and off when transparency (`enable_transparency`) is enabled. The new option is called `enable_transparency_image` and can take the values true/false. The default is set to 'true' (like the behavior of the upstream)

This option is useful in my usecase to be able to draw on a custom background (which should not be part of the canvas)

I also added default value descriptions to README ;)