### PR TITLE
Feature/enable scrollwheel zooming

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ $("#canvas").drawr("start");
 4.  undo_max_levels(5)
 5.  color_mode("presets","picker")
 6.  clear_on_init
+7.  enable_scrollwheel_zooming(true)
 
 [demos and docs at this link](https://rawrfl.es/jquery-drawr/ "demos and docs at this link")
 

--- a/src/jquery.drawr.js
+++ b/src/jquery.drawr.js
@@ -246,23 +246,25 @@
 	        	});
 			};
 
-			//handles scrollwheel zooming
-			self.scrollWheel = function(e){
-				var delta = new Number(e.originalEvent.deltaY * -0.005);
+			if(this.settings.enable_scrollwheel_zooming==true){
+				//handles scrollwheel zooming
+				self.scrollWheel = function(e){
+					var delta = new Number(e.originalEvent.deltaY * -0.005);
 
-				if(delta<0){
-					if(delta<-0.1) delta=-0.1;
-				} else if(delta>0){
-					if(delta>0.1) delta=0.1;
-				}
+					if(delta<0){
+						if(delta<-0.1) delta=-0.1;
+					} else if(delta>0){
+						if(delta>0.1) delta=0.1;
+					}
 
-				var newZoomies = self.zoomFactor + delta;
-    			plugin.apply_zoom.call(self,newZoomies);
-			};
-			$(self).parent().on("wheel.drawr", function(e){ 
-				e.preventDefault(); 
-				self.scrollWheel(e);
-			});
+					var newZoomies = self.zoomFactor + delta;
+					plugin.apply_zoom.call(self,newZoomies);
+				};
+				$(self).parent().on("wheel.drawr", function(e){ 
+					e.preventDefault(); 
+					self.scrollWheel(e);
+				});
+			}
 
 			$(window).bind("touchmove.drawr mousemove.drawr", self.drawMove);
 
@@ -772,6 +774,7 @@
 	        	//determine settings
 		    	var defaultSettings = {
 		    		"enable_tranparency" : true,
+					"enable_scrollwheel_zooming" : false,
 		    		"canvas_width" : $(currentCanvas).parent().innerWidth(),
 		    		"canvas_height" : $(currentCanvas).parent().innerHeight(),
 		    		"undo_max_levels" : 5,

--- a/src/jquery.drawr.js
+++ b/src/jquery.drawr.js
@@ -774,7 +774,7 @@
 	        	//determine settings
 		    	var defaultSettings = {
 		    		"enable_tranparency" : true,
-					"enable_scrollwheel_zooming" : false,
+					"enable_scrollwheel_zooming" : true,
 		    		"canvas_width" : $(currentCanvas).parent().innerWidth(),
 		    		"canvas_height" : $(currentCanvas).parent().innerHeight(),
 		    		"undo_max_levels" : 5,


### PR DESCRIPTION
The following PR adds another option to turn zooming on and off via the mouse wheel.

This option is useful in my usecase to allow scrolling on a fullscreen canvas and keep the drawing always in the original zoom (as long as the magnifier function is not enabled either)

The new option since `enable_scrollwheel_zooming` and can take the values true/false. The default is set to 'true' (like the upstream behavior).

Attention: I set the numbering in the README to the next value in the list. If my previous PR is accepted, this numbering is not correct anymore, because this PR is based on the master branch. Recommendation for a later PRs: Remove numbering in the README if necessary ;)
